### PR TITLE
Fixed attr min

### DIFF
--- a/include/spdlog/async_logger-inl.h
+++ b/include/spdlog/async_logger-inl.h
@@ -14,16 +14,6 @@
 #include <string>
 
 SPDLOG_INLINE spdlog::async_logger::async_logger(
-    std::string logger_name, sinks_init_list sinks_list, attribute_list attrs, std::weak_ptr<details::thread_pool> tp, async_overflow_policy overflow_policy)
-    : async_logger(std::move(logger_name), sinks_list.begin(), sinks_list.end(), std::move(attrs), std::move(tp), overflow_policy)
-{}
-
-SPDLOG_INLINE spdlog::async_logger::async_logger(
-    std::string logger_name, sink_ptr single_sink, attribute_list attrs, std::weak_ptr<details::thread_pool> tp, async_overflow_policy overflow_policy)
-    : async_logger(std::move(logger_name), {std::move(single_sink)}, std::move(attrs), std::move(tp), overflow_policy)
-{}
-
-SPDLOG_INLINE spdlog::async_logger::async_logger(
     std::string logger_name, sinks_init_list sinks_list, std::weak_ptr<details::thread_pool> tp, async_overflow_policy overflow_policy)
     : async_logger(std::move(logger_name), sinks_list.begin(), sinks_list.end(), std::move(tp), overflow_policy)
 {}

--- a/include/spdlog/async_logger.h
+++ b/include/spdlog/async_logger.h
@@ -36,26 +36,12 @@ class SPDLOG_API async_logger final : public std::enable_shared_from_this<async_
 
 public:
     template<typename It>
-    async_logger(std::string logger_name, It begin, It end, attribute_list attrs, std::weak_ptr<details::thread_pool> tp,
-        async_overflow_policy overflow_policy = async_overflow_policy::block)
-        : logger(std::move(logger_name), begin, end, attrs)
-        , thread_pool_(std::move(tp))
-        , overflow_policy_(overflow_policy)
-    {}
-
-    template<typename It>
     async_logger(std::string logger_name, It begin, It end, std::weak_ptr<details::thread_pool> tp,
         async_overflow_policy overflow_policy = async_overflow_policy::block)
         : logger(std::move(logger_name), begin, end)
         , thread_pool_(std::move(tp))
         , overflow_policy_(overflow_policy)
     {}
-
-    async_logger(std::string logger_name, sinks_init_list sinks_list, attribute_list attrs, std::weak_ptr<details::thread_pool> tp,
-        async_overflow_policy overflow_policy = async_overflow_policy::block);
-
-    async_logger(std::string logger_name, sink_ptr single_sink, attribute_list attrs, std::weak_ptr<details::thread_pool> tp,
-        async_overflow_policy overflow_policy = async_overflow_policy::block);
 
     async_logger(std::string logger_name, sinks_init_list sinks_list, std::weak_ptr<details::thread_pool> tp,
         async_overflow_policy overflow_policy = async_overflow_policy::block);

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -95,12 +95,6 @@ public:
         attributes.clear();
     }
 
-    template <typename T>
-    void log(level::level_enum lvl, const T &msg, attribute_list attrs)
-    {
-        log(source_loc{}, lvl, msg, attrs);
-    }
-
     template<typename... Args>
     void log(source_loc loc, level::level_enum lvl, format_string_t<Args...> fmt, Args &&... args)
     {
@@ -140,20 +134,6 @@ public:
         log_it_(log_msg, log_enabled, traceback_enabled);
     }
 
-    void log(source_loc loc, level::level_enum lvl, string_view_t msg, attribute_list attrs)
-    {
-        bool log_enabled = should_log(lvl);
-        bool traceback_enabled = tracer_.enabled();
-        if (!log_enabled && !traceback_enabled)
-        {
-            return;
-        }
-
-        details::log_msg log_msg(loc, name_, lvl, msg);
-        log_msg.attributes.insert(log_msg.attributes.end(), attributes.begin(), attributes.end());
-        log_msg.attributes.insert(log_msg.attributes.end(), attrs.begin(), attrs.end());
-        log_it_(log_msg, log_enabled, traceback_enabled);
-    }
     void log(source_loc loc, level::level_enum lvl, string_view_t msg)
     {
         bool log_enabled = should_log(lvl);
@@ -295,43 +275,6 @@ public:
         log(level::critical, fmt, std::forward<Args>(args)...);
     }
 #endif
-
-    // attributes endpoint
-    template<typename T>
-    void trace(const T &msg, attribute_list attrs)
-    {
-        log(level::trace, msg, attrs);
-    }
-
-    template<typename T>
-    void debug(const T &msg, attribute_list attrs)
-    {
-        log(level::debug, msg, attrs);
-    }
-
-    template<typename T>
-    void info(const T &msg, attribute_list attrs)
-    {
-        log(level::info, msg, attrs);
-    }
-
-    template<typename T>
-    void warn(const T &msg, attribute_list attrs)
-    {
-        log(level::warn, msg, attrs);
-    }
-
-    template<typename T>
-    void error(const T &msg, attribute_list attrs)
-    {
-        log(level::err, msg, attrs);
-    }
-
-    template<typename T>
-    void critical(const T &msg, attribute_list attrs)
-    {
-        log(level::critical, msg, attrs);
-    }
 
     // default endpoint
     template<typename T>


### PR DESCRIPTION
cleaner api uses only set and clear context, as suggested. only add attributes when absolutely necessary. 