### PR TITLE
Fixing attribute overloads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ endif()
 # Compiler config
 # ---------------------------------------------------------------------------------------
 if(NOT CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 11)
+    set(CMAKE_CXX_STANDARD 17)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -394,6 +394,7 @@ void replace_default_logger_example()
 }
 
 void attribute_example() {
+    spdlog::details::Key key = "attribute_key";
     spdlog::push_context(spdlog::attribute_list{{"attribute_key", "attribute value"}});
     spdlog::warn("EXPERIMENTAL: log with attributes");
     spdlog::clear_context();
@@ -412,9 +413,9 @@ void attribute_example() {
     s_logger->set_pattern(std::move(logfmt_pattern));
     #endif
 
-    s_logger->push_context(spdlog::attribute_list{{"key\n1", "value\n1"}});
+    s_logger->push_context(spdlog::attribute_list{{spdlog::attr_sv{"key\n1"}, "value\n1"}});
     s_logger->info("structured logging: test 1");
-    s_logger->push_context(spdlog::attribute_list{{"key\n2", "value\n2"}});
+    s_logger->push_context(spdlog::attribute_list{{spdlog::attr_sv{"key\n2"}, "value\n2"}});
     s_logger->info("structured logging: test 2");
     s_logger->pop_context();
     s_logger->info("structured logging: test 3");

--- a/include/spdlog/details/log_attr.h
+++ b/include/spdlog/details/log_attr.h
@@ -6,26 +6,22 @@
 #include <spdlog/common.h>
 
 namespace spdlog {
+using attr_sv = std::basic_string_view<char>;
+
 namespace details {
 
 // template<typename T>
 // concept composable = std::same_as<T, bool> || std::integral<T> || std::floating_point<T> || std::convertible_to<T, std::string_view>;
-
+// 
 
 struct Key 
 {
     std::string _key;
 
-    Key(string_view_t k) {
-        scramble(_key, k);
+    Key(attr_sv k) {
+        scramble(_key, string_view_t(k.data(), k.size()));
     }
     Key(std::string&& k) {
-        scramble(_key, k);
-    }
-    Key(std::string const& k) {
-        scramble(_key, k);
-    }
-    Key(const char* k) {
         scramble(_key, k);
     }
 };
@@ -42,9 +38,6 @@ struct Value
         scramble(_value, v);
     }
     Value(std::string const& v) {
-        scramble(_value, v);
-    }
-    Value(const char* v) {
         scramble(_value, v);
     }
     
@@ -82,18 +75,16 @@ struct Value
     Value(unsigned long long v) {
         _value = std::to_string(v);
     }
-    Value(float v) {
-        _value = std::to_string(v);
-    }
-    Value(double v) {
-        _value = std::to_string(v);
-    }
-    Value(long double v) {
-        _value = std::to_string(v);
-    }
-    Value(bool v) {
-        _value = v ? "true" : "false";
-    }
+    // floating point conversion to string is weird, let the api user do it
+    // Value(float v) {
+    //     _value = std::to_string(v);
+    // }
+    // Value(double v) {
+    //     _value = std::to_string(v);
+    // }
+    // Value(long double v) {
+    //     _value = std::to_string(v);
+    // }
 };
 
 struct attr


### PR DESCRIPTION
we are trying to get rid of the const char * overload, but its not working. Even with modern string view it has issues. What's weird is it works fine with values, but not with keys (unless its just not getting checked yet). Will have to investigate. Will leave working code in master and try fixing in this branch. 