### PR TITLE
[BUGFIX] Wrong overload chosen for to_string_view on newer MSVC

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -370,18 +370,18 @@ inline fmt::basic_string_view<T> to_string_view(fmt::basic_format_string<T, Args
 {
     return fmt;
 }
-#elif __cpp_lib_format >= 202207L
-template<typename T, typename... Args>
-SPDLOG_CONSTEXPR_FUNC std::basic_string_view<T> to_string_view(std::basic_format_string<T, Args...> fmt) SPDLOG_NOEXCEPT
-{
-    return fmt.get();
-}
 #elif defined(SPDLOG_USE_STD_STRING_VIEW) && !defined(SPDLOG_USE_STD_FORMAT)
 template<typename T, typename... Args>
 SPDLOG_CONSTEXPR_FUNC std::basic_string_view<T> to_string_view(fmt::basic_format_string<T, Args...> fmt) SPDLOG_NOEXCEPT
 {
     auto tmp = fmt::basic_string_view<T>{fmt};
     return std::string_view{tmp.data(), tmp.size()};
+}
+#elif __cpp_lib_format >= 202207L
+template<typename T, typename... Args>
+SPDLOG_CONSTEXPR_FUNC std::basic_string_view<T> to_string_view(std::basic_format_string<T, Args...> fmt) SPDLOG_NOEXCEPT
+{
+    return fmt.get();
 }
 #endif
 


### PR DESCRIPTION
s. https://github.com/tessonics/spdlog/commit/4544acfab3f739c3184ea37bd759d181098432be#r107619247

The if-else branches were not ordered correctly.
I updated MSVC to 17.5.3 more current compiler and it would jump into the second branch which fails `!SPDLOG_USE_STD_FORMAT` because it would try to convert `fmt::format_string` to `std::format_string`