### PR TITLE
Rotating log message

### DIFF
--- a/include/spdlog/sinks/rotating_file_sink.h
+++ b/include/spdlog/sinks/rotating_file_sink.h
@@ -21,7 +21,14 @@ public:
                        std::size_t max_size,
                        std::size_t max_files,
                        bool rotate_on_open = false,
-                       const file_event_handlers &event_handlers = {});
+                       const file_event_handlers &event_handlers = {},
+                       const details::log_msg &new_file_message = {});
+
+    rotating_file_sink(filename_t base_filename,
+                       std::size_t max_size,
+                       std::size_t max_files,
+                       bool rotate_on_open,
+                       const details::log_msg &new_file_message);
 
     static filename_t calc_filename(const filename_t &filename, std::size_t index);
     filename_t filename();
@@ -48,6 +55,7 @@ private:
     std::size_t max_files_;
     std::size_t current_size_;
     details::file_helper file_helper_;
+    details::log_msg new_file_message_;
 };
 
 using rotating_file_sink_mt = rotating_file_sink<std::mutex>;

--- a/include/spdlog/sinks/rotating_file_sink.h
+++ b/include/spdlog/sinks/rotating_file_sink.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <mutex>
+#include <optional>
 #include <string>
 
 #include "../details/file_helper.h"
@@ -17,18 +18,20 @@ namespace sinks {
 template <typename Mutex>
 class rotating_file_sink final : public base_sink<Mutex> {
 public:
+    using file_rotation_event_handler = std::function<std::optional<details::log_msg>(const filename_t &)>;
+
     rotating_file_sink(filename_t base_filename,
                        std::size_t max_size,
                        std::size_t max_files,
                        bool rotate_on_open = false,
                        const file_event_handlers &event_handlers = {},
-                       const details::log_msg &new_file_message = {});
+                       file_rotation_event_handler file_rotating_event_callback = nullptr);
 
     rotating_file_sink(filename_t base_filename,
                        std::size_t max_size,
                        std::size_t max_files,
                        bool rotate_on_open,
-                       const details::log_msg &new_file_message);
+                       file_rotation_event_handler file_rotating_event_callback);
 
     static filename_t calc_filename(const filename_t &filename, std::size_t index);
     filename_t filename();
@@ -55,7 +58,7 @@ private:
     std::size_t max_files_;
     std::size_t current_size_;
     details::file_helper file_helper_;
-    details::log_msg new_file_message_;
+    file_rotation_event_handler file_rotating_event_callback_;
 };
 
 using rotating_file_sink_mt = rotating_file_sink<std::mutex>;

--- a/src/sinks/rotating_file_sink.cpp
+++ b/src/sinks/rotating_file_sink.cpp
@@ -21,11 +21,13 @@ rotating_file_sink<Mutex>::rotating_file_sink(filename_t base_filename,
                                               std::size_t max_size,
                                               std::size_t max_files,
                                               bool rotate_on_open,
-                                              const file_event_handlers &event_handlers)
+                                              const file_event_handlers &event_handlers,
+                                              const details::log_msg &new_file_message)
     : base_filename_(std::move(base_filename)),
       max_size_(max_size),
       max_files_(max_files),
-      file_helper_{event_handlers} {
+      file_helper_{event_handlers},
+      new_file_message_{new_file_message} {
     if (max_size == 0) {
         throw_spdlog_ex("rotating sink constructor: max_size arg cannot be zero");
     }
@@ -40,6 +42,14 @@ rotating_file_sink<Mutex>::rotating_file_sink(filename_t base_filename,
         current_size_ = 0;
     }
 }
+
+template <typename Mutex>
+rotating_file_sink<Mutex>::rotating_file_sink(filename_t base_filename,
+                                              std::size_t max_size,
+                                              std::size_t max_files,
+                                              bool rotate_on_open,
+                                              const details::log_msg &new_file_message)
+    : rotating_file_sink(base_filename, max_size, max_files, rotate_on_open, {}, new_file_message) {}
 
 // calc filename according to index and file extension if exists.
 // e.g. calc_filename("logs/mylog.txt, 3) => "logs/mylog.3.txt".
@@ -127,6 +137,10 @@ void rotating_file_sink<Mutex>::rotate_() {
         }
     }
     file_helper_.reopen(true);
+    if (!new_file_message_.payload.empty()) {
+        new_file_message_.time = details::os::now();
+        sink_it_(new_file_message_);
+    }
 }
 
 // delete the target if exists, and rename the src file  to target

--- a/src/sinks/rotating_file_sink.cpp
+++ b/src/sinks/rotating_file_sink.cpp
@@ -22,12 +22,12 @@ rotating_file_sink<Mutex>::rotating_file_sink(filename_t base_filename,
                                               std::size_t max_files,
                                               bool rotate_on_open,
                                               const file_event_handlers &event_handlers,
-                                              const details::log_msg &new_file_message)
+                                              file_rotation_event_handler file_rotating_event_callback)
     : base_filename_(std::move(base_filename)),
       max_size_(max_size),
       max_files_(max_files),
       file_helper_{event_handlers},
-      new_file_message_{new_file_message} {
+      file_rotating_event_callback_{file_rotating_event_callback} {
     if (max_size == 0) {
         throw_spdlog_ex("rotating sink constructor: max_size arg cannot be zero");
     }
@@ -48,8 +48,8 @@ rotating_file_sink<Mutex>::rotating_file_sink(filename_t base_filename,
                                               std::size_t max_size,
                                               std::size_t max_files,
                                               bool rotate_on_open,
-                                              const details::log_msg &new_file_message)
-    : rotating_file_sink(base_filename, max_size, max_files, rotate_on_open, {}, new_file_message) {}
+                                              file_rotation_event_handler file_rotating_event_callback)
+    : rotating_file_sink(base_filename, max_size, max_files, rotate_on_open, {}, file_rotating_event_callback) {}
 
 // calc filename according to index and file extension if exists.
 // e.g. calc_filename("logs/mylog.txt, 3) => "logs/mylog.3.txt".
@@ -137,9 +137,9 @@ void rotating_file_sink<Mutex>::rotate_() {
         }
     }
     file_helper_.reopen(true);
-    if (!new_file_message_.payload.empty()) {
-        new_file_message_.time = details::os::now();
-        sink_it_(new_file_message_);
+    if (file_rotating_event_callback_) {
+        auto msg = file_rotating_event_callback_(file_helper_.filename());
+        if (msg) sink_it_(*msg);
     }
 }
 

--- a/tests/test_file_logging.cpp
+++ b/tests/test_file_logging.cpp
@@ -108,11 +108,32 @@ TEST_CASE("rotating_file_logger4", "[rotating_logger]") {
 }
 
 TEST_CASE("rotating_file_logger5", "[rotating_logger]") {
+    auto empty_callback = [](const spdlog::filename_t &) -> std::optional<spdlog::details::log_msg> { return {}; };
+
     prepare_logdir();
     size_t max_size = 1024 * 10;
     spdlog::filename_t basename = SPDLOG_FILENAME_T(ROTATING_LOG);
-    auto rotating_msg = spdlog::details::log_msg("ROTATING_FILE_SINK", spdlog::level::info, "rotating file");
-    auto sink = std::make_shared<spdlog::sinks::rotating_file_sink_st>(basename, max_size, 2, false, rotating_msg);
+    auto sink = std::make_shared<spdlog::sinks::rotating_file_sink_st>(basename, max_size, 2, false, empty_callback);
+    auto logger = std::make_shared<spdlog::logger>("rotating_sink_logger", sink);
+    logger->info("Test message - pre-rotation");
+    logger->flush();
+    sink->rotate_now();
+    logger->info("Test message - post-rotation");
+    logger->flush();
+    REQUIRE(get_filesize(ROTATING_LOG) > 0);
+    REQUIRE(get_filesize(ROTATING_LOG ".1") > 0);
+    require_message_count(ROTATING_LOG, 1);
+}
+
+TEST_CASE("rotating_file_logger6", "[rotating_logger]") {
+    auto empty_callback = [](const spdlog::filename_t &) -> std::optional<spdlog::details::log_msg> {
+        return spdlog::details::log_msg{spdlog::log_clock::now(), {}, "COMMON", spdlog::level::info, "rotating file log message"};
+    };
+
+    prepare_logdir();
+    size_t max_size = 1024 * 10;
+    spdlog::filename_t basename = SPDLOG_FILENAME_T(ROTATING_LOG);
+    auto sink = std::make_shared<spdlog::sinks::rotating_file_sink_st>(basename, max_size, 2, false, empty_callback);
     auto logger = std::make_shared<spdlog::logger>("rotating_sink_logger", sink);
     logger->info("Test message - pre-rotation");
     logger->flush();

--- a/tests/test_file_logging.cpp
+++ b/tests/test_file_logging.cpp
@@ -106,3 +106,20 @@ TEST_CASE("rotating_file_logger4", "[rotating_logger]") {
     REQUIRE(get_filesize(ROTATING_LOG) > 0);
     REQUIRE(get_filesize(ROTATING_LOG ".1") > 0);
 }
+
+TEST_CASE("rotating_file_logger5", "[rotating_logger]") {
+    prepare_logdir();
+    size_t max_size = 1024 * 10;
+    spdlog::filename_t basename = SPDLOG_FILENAME_T(ROTATING_LOG);
+    auto rotating_msg = spdlog::details::log_msg("ROTATING_FILE_SINK", spdlog::level::info, "rotating file");
+    auto sink = std::make_shared<spdlog::sinks::rotating_file_sink_st>(basename, max_size, 2, false, rotating_msg);
+    auto logger = std::make_shared<spdlog::logger>("rotating_sink_logger", sink);
+    logger->info("Test message - pre-rotation");
+    logger->flush();
+    sink->rotate_now();
+    logger->info("Test message - post-rotation");
+    logger->flush();
+    REQUIRE(get_filesize(ROTATING_LOG) > 0);
+    REQUIRE(get_filesize(ROTATING_LOG ".1") > 0);
+    require_message_count(ROTATING_LOG, 2);
+}

--- a/tests/test_file_logging.cpp
+++ b/tests/test_file_logging.cpp
@@ -126,14 +126,14 @@ TEST_CASE("rotating_file_logger5", "[rotating_logger]") {
 }
 
 TEST_CASE("rotating_file_logger6", "[rotating_logger]") {
-    auto empty_callback = [](const spdlog::filename_t &) -> std::optional<spdlog::details::log_msg> {
+    auto callback = [](const spdlog::filename_t &) -> std::optional<spdlog::details::log_msg> {
         return spdlog::details::log_msg{spdlog::log_clock::now(), {}, "COMMON", spdlog::level::info, "rotating file log message"};
     };
 
     prepare_logdir();
     size_t max_size = 1024 * 10;
     spdlog::filename_t basename = SPDLOG_FILENAME_T(ROTATING_LOG);
-    auto sink = std::make_shared<spdlog::sinks::rotating_file_sink_st>(basename, max_size, 2, false, empty_callback);
+    auto sink = std::make_shared<spdlog::sinks::rotating_file_sink_st>(basename, max_size, 2, false, callback);
     auto logger = std::make_shared<spdlog::logger>("rotating_sink_logger", sink);
     logger->info("Test message - pre-rotation");
     logger->flush();


### PR DESCRIPTION
Added the option to add a custom log msg to the beginning of each file for the rotating_file_sink 

Could be used to add the version of the application in each of the log files..